### PR TITLE
fix: clear cudaErrorMemoryAllocation from cudaGetLastError() in MSM's dry run

### DIFF
--- a/src/msm.cu
+++ b/src/msm.cu
@@ -443,6 +443,9 @@ cudaError_t execute_async(const execution_configuration &exec_cfg) {
     extended_configuration cfg = {exec_cfg, scalars_attributes, bases_attributes, results_attributes, log_min_inputs_count, log_max_inputs_count, props};
     cudaError_t error = schedule_execution(cfg, true);
     if (error == cudaErrorMemoryAllocation) {
+      error = cudaGetLastError();
+      if (error != cudaErrorMemoryAllocation && error != cudaSuccess)
+        return error;
       log_max_inputs_count--;
       if (!copy_scalars)
         log_min_inputs_count--;


### PR DESCRIPTION
# What ❔

This PR fixes a bug which caused some subsequent CUDA calls to fail because `cudaGetLastError()` was not cleared and was returning the error from dry run.
