### PR TITLE
chore: dead link docs in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ We aim to make it as easy as possible to contribute to the mission. This is stil
 and suggestions here too. Some resources to help:
 
 1. [In-repo docs aimed at developers](docs)
-2. [zkSync Era docs!](https://era.zksync.io/docs/)
+2. [zkSync Era docs!](https://docs.zksync.io/zksync-era)
 3. Company links can be found in the [repo's readme](README.md)
 
 ## Code of Conduct


### PR DESCRIPTION
# What ❔

Hi! I updates a dead link in the CONTRIBUTING.md file. The old link pointing to era.zksync.io/docs/ has been replaced with the correct URL https://docs.zksync.io/zksync-era. This ensures that contributors are directed to the correct and up-to-date documentation.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
