### PR TITLE
chore: Fix dead link in in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@ We truly appreciate your efforts to discover and disclose security issues respon
 ## Vulnerabilities
 
 If you'd like to report a security issue in the repositories of matter-labs organization, please proceed to our
-[Bug Bounty Program on Immunefi](https://era.zksync.io/docs/reference/troubleshooting/audit-bug-bounty.html#bug-bounty-program).
+[Bug Bounty Program on Immunefi](https://immunefi.com/bounty/zksyncera/).
 
 ## Other Security Issues
 


### PR DESCRIPTION
# What ❔

The old link pointing to https://era.zksync.io/docs/reference/troubleshooting/audit-bug-bounty.html#bug-bounty-program (404 error) has been replaced with the correct URL - https://immunefi.com/bounty/zksyncera/

This ensures that contributors are directed to the correct and up-to-date documentation.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
