### PR TITLE
fix: replace <cub/cub.cuh> umbrella include with specific CUB headers

### DIFF
--- a/src/bellman-cuda-cub.cu
+++ b/src/bellman-cuda-cub.cu
@@ -1,6 +1,9 @@
 #include "bellman-cuda-cub.cuh"
 #include "ff_dispatch_st.cuh"
-#include <cub/cub.cuh>
+#include <cub/device/device_radix_sort.cuh>
+#include <cub/device/device_reduce.cuh>
+#include <cub/device/device_run_length_encode.cuh>
+#include <cub/device/device_scan.cuh>
 
 namespace common {
 

--- a/src/pn_kernels.cu
+++ b/src/pn_kernels.cu
@@ -1,7 +1,7 @@
 #include "common.cuh"
 #include "ff_kernels.cuh"
 #include "pn_kernels.cuh"
-#include <cub/cub.cuh>
+#include <cub/warp/warp_store.cuh>
 
 namespace pn {
 


### PR DESCRIPTION
# What ❔

Replace `#include <cub/cub.cuh>` with the specific CUB headers actually used:

- [src/bellman-cuda-cub.cu](src/bellman-cuda-cub.cu) → `device_radix_sort`, `device_reduce`, `device_run_length_encode`, `device_scan`
- [src/pn_kernels.cu](src/pn_kernels.cu) → `warp/warp_store`

## Why ❔

Fixes the build on CUDA 13.2. The umbrella header transitively pulls in `cub/block/block_load_to_shared.cuh` (new in CUB 3.2.0), which has an ambiguous unqualified `data()` call on `cuda::std::span` under libstdc++ 13. Avoiding the umbrella sidesteps the broken header. Verified clean builds and identical test results on CUDA 12.9, 13.1, and 13.2.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.